### PR TITLE
Return named groups on output

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -36,9 +36,12 @@ function run() {
                         core.warning(`Failed to match regex '${regexStr}' in tag string '${tag}'. Result is '${result}'`);
                         return;
                     }
-                    result.forEach((match, index) => {
-                        core.setOutput('match' + index, match);
-                    });
+                    // Return named groups on output
+                    if (result.groups) {
+                        for (const [key, value] of Object.entries(result.groups)) {
+                            core.setOutput(key, value);
+                        }
+                    }
                 }
                 core.exportVariable("GIT_TAG_NAME", tag);
                 core.setOutput('tag', tag);

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,6 +36,9 @@ function run() {
                         core.warning(`Failed to match regex '${regexStr}' in tag string '${tag}'. Result is '${result}'`);
                         return;
                     }
+                    result.forEach((match, index) => {
+                        core.setOutput('match' + index, match);
+                    });
                 }
                 core.exportVariable("GIT_TAG_NAME", tag);
                 core.setOutput('tag', tag);

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,10 @@ async function run() {
           core.warning(`Failed to match regex '${regexStr}' in tag string '${tag}'. Result is '${result}'`)
           return
         }
+        
+        result.forEach((match, index) => {
+          core.setOutput('match' + index, match);
+        });
       }
       core.exportVariable("GIT_TAG_NAME", tag);
       core.setOutput('tag', tag);

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,10 +19,13 @@ async function run() {
           core.warning(`Failed to match regex '${regexStr}' in tag string '${tag}'. Result is '${result}'`)
           return
         }
-        
-        result.forEach((match, index) => {
-          core.setOutput('match' + index, match);
-        });
+
+        // Return named groups on output
+        if (result.groups) {
+          for (const [key, value] of Object.entries(result.groups)) {
+            core.setOutput(key, value);
+          }
+        }
       }
       core.exportVariable("GIT_TAG_NAME", tag);
       core.setOutput('tag', tag);


### PR DESCRIPTION
Added feature to add named capture groups from regex to output object.
Makes it easy to capture multiple strings from tag.

This is key if one is working in a monorepo with multiple codebases:

```yaml
    steps:
      - uses: jelgblad/get-tag@named-groups
        id: tagName
        with:
          tagRegex: "(?<package>.*)-(?<version>.*)" 
      - name: Some other step # Output usage example
        with:
          dirname: ${{ steps.tagName.outputs.package }}
          tagname: ${{ steps.tagName.outputs.version }}
```

Does not break anything in v2.

A more elegant solution in v3 would be to remove the `tagRegexGroup`-option and simply let the users of this action name their capture groups freely and just fall back to:
- Set `tag`-output to group 1, if no groups where named.
- Set `tag`-output full tag string, if no groups OR no regex.

But thats not in this PR.
