### PR TITLE
Add description of input parameters

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,13 @@ author: 'Oleg Tarasov'
 runs:
   using: 'node12'
   main: 'lib/main.js'
+inputs:
+  tagRegex:
+    description: 'Regex to capture a group text as tag name. Full tag string is returned if regex is not defined.'
+    default: ''
+  tagRegexGroup:
+    description: 'Regex group number to return as tag name.'
+    default: '1'
 outputs:
   tag:
     description: The tag name.


### PR DESCRIPTION
This stops GitHub Actions from adding warnings about "Unexpected input(s)" to a run.

Closes #8﻿
